### PR TITLE
エラー直したつもり

### DIFF
--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -18,36 +18,35 @@ export default {
       return this.$store.getters['buildings/all']
     }
   },
-  async asyncData({ store }) {
-    // TODO: 最初にまとめて呼べるようにしたい
-    await Promise.all([
-      store.dispatch('buildings/fetchByCanmpusId', { campusId: 1 })
-    ])
+  async asyncData({ store, $auth }) {
+    if ($auth.$storage.getUniversal('strategy') === 'local' && $auth.loggedIn) {
+      await Promise.all([
+        store.dispatch('buildings/fetchByCampusId', { campusId: 1 })
+      ])
+    }
   },
   beforeCreate() {
-    if (process.client) {
-      switch (this.$auth.$storage.getUniversal('strategy')) {
-        case 'waseda':
-          setTimeout(() => {
-            this.$auth
-              .loginWith('local', {
-                headers: {
-                  authorization: this.$auth.$storage.getUniversal(
-                    '_token.waseda'
-                  )
-                }
-              })
-              .then((result) => {
-                this.$toast.success('ログインしました')
-              })
-              .catch((e) => {
-                this.$toast.error('ログインできませんでした')
-              })
-          }, 1000)
-          break
-        default:
-          break
-      }
+    if (
+      process.client &&
+      this.$auth.$storage.getUniversal('strategy') === 'waseda'
+    ) {
+      setTimeout(() => {
+        this.$auth
+          .loginWith('local', {
+            headers: {
+              authorization: this.$auth.$storage.getUniversal('_token.waseda')
+            }
+          })
+          .then((result) => {
+            this.$toast.success('ログインしました')
+            this.$store.dispatch('buildings/fetchByCampusId', { campusId: 1 })
+            this.$auth.$storage.removeUniversal('waseda.state')
+            this.$auth.$storage.removeUniversal('_token.waseda')
+          })
+          .catch((e) => {
+            this.$toast.error('ログインできませんでした')
+          })
+      }, 1000)
     }
   }
 }

--- a/client/pages/index.vue
+++ b/client/pages/index.vue
@@ -30,23 +30,21 @@ export default {
       process.client &&
       this.$auth.$storage.getUniversal('strategy') === 'waseda'
     ) {
-      setTimeout(() => {
-        this.$auth
-          .loginWith('local', {
-            headers: {
-              authorization: this.$auth.$storage.getUniversal('_token.waseda')
-            }
-          })
-          .then((result) => {
-            this.$toast.success('ログインしました')
-            this.$store.dispatch('buildings/fetchByCampusId', { campusId: 1 })
-            this.$auth.$storage.removeUniversal('waseda.state')
-            this.$auth.$storage.removeUniversal('_token.waseda')
-          })
-          .catch((e) => {
-            this.$toast.error('ログインできませんでした')
-          })
-      }, 1000)
+      this.$auth
+        .loginWith('local', {
+          headers: {
+            authorization: this.$auth.$storage.getUniversal('_token.waseda')
+          }
+        })
+        .then((result) => {
+          this.$toast.success('ログインしました')
+          this.$store.dispatch('buildings/fetchByCampusId', { campusId: 1 })
+          this.$auth.$storage.removeUniversal('waseda.state')
+          this.$auth.$storage.removeUniversal('_token.waseda')
+        })
+        .catch((e) => {
+          this.$toast.error('ログインできませんでした')
+        })
     }
   }
 }

--- a/client/store/buildings.js
+++ b/client/store/buildings.js
@@ -13,7 +13,7 @@ export const mutations = {
 }
 
 export const actions = {
-  async fetchByCanmpusId({ state, commit }, { campusId }) {
+  async fetchByCampusId({ state, commit }, { campusId }) {
     if (state.buildings.length > 0) return
     const { data } = await this.$axios.get(`buildings/campusId/${campusId}`)
     commit('setAll', { buildings: data.buildings })


### PR DESCRIPTION
# 認証機構
1. loginページでログインボタンを押す(strategy: waseda)
2. googleの認証ページにリダイレクト
3. wasedaメールでgoogle認証し、googleからtokenを取得
4. loginページにリダイレクト
5. indexページにリダイレクト
6. beforeCreateで、googleのtokenを使ってapiのauth/wasedaを叩いてaccessToken(jwt)を取得(strategy: local)
7. 以降accessTokenを使用してapiにアクセス

# 今回直そうとしてるエラー
6でbeforeCreateする前にasyncDataのbuildings/fetchByCampusIdが呼ばれてしまい、この時点でaccessTokenがないので401が帰ってきてエラーになってしまう
-> buildings/fetchByCampusIdを叩くのを、strategyがlocalでloggedInがtrueの状況のみにし、
     初回ログイン時のbuildings/fetchByCampusIdはbeforeCreateで叩くように分けた